### PR TITLE
gaurd against no trace

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,9 @@ var asyncHandlers = {
   },
   error : function error(trace, error) {
     // replace the short stack with the long stack
-    error.stack = activeTrace.toString(error.stack);
+    if (activeTrace) {
+      error.stack = activeTrace.toString(error.stack);
+    }
 
     // do *not* handle the error, let it propagate
     // chances are things are about to crash, we don't


### PR DESCRIPTION
I think there is a race condition where there is no trace.

Probably something in the async-listener shim or some kind of sync race
  condition.

Don't know what the root cause fix is but we can at least gaurd against this

cc @sh1mmer cc @groundwater
