### PR TITLE
Adds repository entry to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "main": "longtrace.js",
   "author": "Jacob Groundwater <groundwater@gmail.com>",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/groundwater/node-stackup.git"
+  },
   "dependencies": {
     "async-listener": "~0.2.2"
   }


### PR DESCRIPTION
...to quieten this sort of thing when installing a module with a dependency on stackup:

```sh
npm WARN package.json stackup@0.0.5 No repository field.
```