### PR TITLE
Dynamically figure out async-listener location from require.resolve

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,8 +2,8 @@
 
 if(!process.addAsyncListener)
                   require('async-listener');
-var util        = require('util');
-var TraceModule = require('./trace')(Error, __dirname + '/node_modules/async-listener');
+var path        = require('path');
+var TraceModule = require('./trace')(Error, path.dirname(require.resolve('async-listener')));
 
 Error.stackTraceLimit = Infinity;
 


### PR DESCRIPTION
First off, I don't know if this module is still used/maintained but I'm playing around with async stack traces at the moment and I came up against what seems to be the same as #10.

npm doesn't always install `async-listener` as a nested dependency of this module, so look it using the same algorithm as `require()` to ensure the stack frames are correctly filtered. I also removed the unused `util` import.

This appears to fix #10 (it certainly removes all the stack frames relating to `'async-listener'` for me, but since there's been no activity for… years(?)… maybe it's not needed. Anyhow, merge if you like!