### PR TITLE
Update peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,62 @@
 {
   "name": "stackup",
   "version": "1.0.2",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
-  "dependencies": {
-    "async-listener": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/async-listener/-/async-listener-0.4.7.tgz",
-      "integrity": "sha1-DY45ALMY4tY8WHGCIRoe7zu1u4I=",
-      "requires": {
-        "shimmer": "1.0.0"
+  "packages": {
+    "": {
+      "name": "stackup",
+      "version": "1.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "async-listener": "0.6.10"
       }
     },
+    "node_modules/async-listener": {
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/async-listener/-/async-listener-0.6.10.tgz",
+      "integrity": "sha512-gpuo6xOyF4D5DE5WvyqZdPA3NGhiT6Qf07l7DCB0wwDEsLvDIbCr6j9S5aj5Ch96dLace5tXVzWBZkxU/c5ohw==",
+      "dependencies": {
+        "semver": "^5.3.0",
+        "shimmer": "^1.1.0"
+      },
+      "engines": {
+        "node": "<=0.11.8 || >0.11.10"
+      }
+    },
+    "node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/shimmer": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
+      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
+    }
+  },
+  "dependencies": {
+    "async-listener": {
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/async-listener/-/async-listener-0.6.10.tgz",
+      "integrity": "sha512-gpuo6xOyF4D5DE5WvyqZdPA3NGhiT6Qf07l7DCB0wwDEsLvDIbCr6j9S5aj5Ch96dLace5tXVzWBZkxU/c5ohw==",
+      "requires": {
+        "semver": "^5.3.0",
+        "shimmer": "^1.1.0"
+      }
+    },
+    "semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+    },
     "shimmer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.0.0.tgz",
-      "integrity": "sha1-ScLXHGeDYLgCvhiyeDgtHLuAXDk="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
+      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,43 +1,8 @@
 {
   "name": "stackup",
-  "version": "1.0.2",
-  "lockfileVersion": 2,
+  "version": "1.0.3",
+  "lockfileVersion": 1,
   "requires": true,
-  "packages": {
-    "": {
-      "name": "stackup",
-      "version": "1.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "async-listener": "0.6.10"
-      }
-    },
-    "node_modules/async-listener": {
-      "version": "0.6.10",
-      "resolved": "https://registry.npmjs.org/async-listener/-/async-listener-0.6.10.tgz",
-      "integrity": "sha512-gpuo6xOyF4D5DE5WvyqZdPA3NGhiT6Qf07l7DCB0wwDEsLvDIbCr6j9S5aj5Ch96dLace5tXVzWBZkxU/c5ohw==",
-      "dependencies": {
-        "semver": "^5.3.0",
-        "shimmer": "^1.1.0"
-      },
-      "engines": {
-        "node": "<=0.11.8 || >0.11.10"
-      }
-    },
-    "node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/shimmer": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
-      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
-    }
-  },
   "dependencies": {
     "async-listener": {
       "version": "0.6.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stackup",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Long stack traces based on async listeners",
   "main": "longtrace.js",
   "author": "Jacob Groundwater <groundwater@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,6 @@
     "url": "git://github.com/groundwater/node-stackup.git"
   },
   "dependencies": {
-    "async-listener": "0.6.10"
+    "async-listener": "~0.6.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,6 @@
     "url": "git://github.com/groundwater/node-stackup.git"
   },
   "dependencies": {
-    "async-listener": "~0.4.7"
+    "async-listener": "0.6.10"
   }
 }


### PR DESCRIPTION
Need to update async-listener to avoid incompatibility with new NodeJS versions. So native async-hooks are still experimental in Node and we use this module to provide long stack trace.